### PR TITLE
Better critical time-step selector

### DIFF
--- a/include/postprocessors/BetterCriticalTimeStep.h
+++ b/include/postprocessors/BetterCriticalTimeStep.h
@@ -1,22 +1,10 @@
-//* This file is part of the MOOSE framework
-//* https://www.mooseframework.org
-//*
-//* All rights reserved, see COPYRIGHT for full restrictions
-//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
-//*
-//* Licensed under LGPL 2.1, please see LICENSE for details
-//* https://www.gnu.org/licenses/lgpl-2.1.html
+//* This file is part of the RACCOON application
+//* being developed at Dolbow lab at Duke University
+//* http://dolbow.pratt.duke.edu
 
 #pragma once
 
 #include "ElementPostprocessor.h"
-
-/**
- * Compute the critical time step for an explicit integration scheme by inferring an
- * effective_stiffness from element classes and density from the user.
- */
-
-// Forward Declarations
 
 class BetterCriticalTimeStep : public ElementPostprocessor
 {
@@ -34,11 +22,9 @@ public:
 
 protected:
   /// Density of the material
-  const MaterialPropertyName _rho_name;
   const MaterialProperty<Real> & _material_density;
 
-  /// Effective stiffness of element: function of material properties and element size
-  const MaterialPropertyName _E_name;
+  /// Effective stiffness of element
   const MaterialProperty<Real> & _effective_stiffness;
 
   /// User defined factor to be multiplied to the critical time step
@@ -46,5 +32,6 @@ protected:
 
   /// Critical time step for explicit solver
   Real _critical_time;
+  /// Material wave speed
   Real _c;
 };

--- a/include/postprocessors/BetterCriticalTimeStep.h
+++ b/include/postprocessors/BetterCriticalTimeStep.h
@@ -1,0 +1,50 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#pragma once
+
+#include "ElementPostprocessor.h"
+
+/**
+ * Compute the critical time step for an explicit integration scheme by inferring an
+ * effective_stiffness from element classes and density from the user.
+ */
+
+// Forward Declarations
+
+class BetterCriticalTimeStep : public ElementPostprocessor
+{
+public:
+  static InputParameters validParams();
+
+  BetterCriticalTimeStep(const InputParameters & parameters);
+
+  virtual void initialize() override {}
+  virtual void execute() override;
+
+  virtual void finalize() override;
+  virtual PostprocessorValue getValue() override;
+  virtual void threadJoin(const UserObject & y) override;
+
+protected:
+  /// Density of the material
+  const MaterialPropertyName _rho_name;
+  const MaterialProperty<Real> & _material_density;
+
+  /// Effective stiffness of element: function of material properties and element size
+  const MaterialPropertyName _E_name;
+  const MaterialProperty<Real> & _effective_stiffness;
+
+  /// User defined factor to be multiplied to the critical time step
+  const Real & _factor;
+
+  /// Critical time step for explicit solver
+  Real _critical_time;
+  Real _c;
+};

--- a/src/postprocessors/BetterCriticalTimeStep.C
+++ b/src/postprocessors/BetterCriticalTimeStep.C
@@ -1,11 +1,6 @@
-//* This file is part of the MOOSE framework
-//* https://www.mooseframework.org
-//*
-//* All rights reserved, see COPYRIGHT for full restrictions
-//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
-//*
-//* Licensed under LGPL 2.1, please see LICENSE for details
-//* https://www.gnu.org/licenses/lgpl-2.1.html
+//* This file is part of the RACCOON application
+//* being developed at Dolbow lab at Duke University
+//* http://dolbow.pratt.duke.edu
 
 #include "BetterCriticalTimeStep.h"
 
@@ -27,10 +22,8 @@ BetterCriticalTimeStep::validParams()
 
 BetterCriticalTimeStep::BetterCriticalTimeStep(const InputParameters & parameters)
   : ElementPostprocessor(parameters),
-    _rho_name(getParam<MaterialPropertyName>("density_name")),
-    _material_density(getMaterialPropertyByName<Real>(_rho_name)),
-    _E_name(getParam<MaterialPropertyName>("E_name")),
-    _effective_stiffness(getMaterialPropertyByName<Real>(_E_name)),
+    _material_density(getMaterialProperty("density_name")),
+    _effective_stiffness(getMaterialProperty("E_name")),
     _factor(getParam<Real>("factor")),
     _critical_time(std::numeric_limits<Real>::max())
 {
@@ -39,13 +32,11 @@ BetterCriticalTimeStep::BetterCriticalTimeStep(const InputParameters & parameter
 void
 BetterCriticalTimeStep::execute()
 {
-  // Real dens = _material_density[0];
   _c = std::numeric_limits<Real>::min();
   for (unsigned qp = 0; qp < _q_point.size(); ++qp)
   {
     _c = std::max(_c, _effective_stiffness[qp] / std::sqrt(_material_density[qp]));
   }
-  // std::cout << _c << std::endl;
   _critical_time = std::min(_factor * _current_elem->hmin() / _c, _critical_time);
 }
 

--- a/src/postprocessors/BetterCriticalTimeStep.C
+++ b/src/postprocessors/BetterCriticalTimeStep.C
@@ -22,8 +22,8 @@ BetterCriticalTimeStep::validParams()
 
 BetterCriticalTimeStep::BetterCriticalTimeStep(const InputParameters & parameters)
   : ElementPostprocessor(parameters),
-    _material_density(getMaterialProperty("density_name")),
-    _effective_stiffness(getMaterialProperty("E_name")),
+    _material_density(getMaterialProperty<Real>("density_name")),
+    _effective_stiffness(getMaterialProperty<Real>("E_name")),
     _factor(getParam<Real>("factor")),
     _critical_time(std::numeric_limits<Real>::max())
 {

--- a/src/postprocessors/BetterCriticalTimeStep.C
+++ b/src/postprocessors/BetterCriticalTimeStep.C
@@ -1,0 +1,69 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "BetterCriticalTimeStep.h"
+
+registerMooseObject("raccoonApp", BetterCriticalTimeStep);
+
+InputParameters
+BetterCriticalTimeStep::validParams()
+{
+  InputParameters params = ElementPostprocessor::validParams();
+  params.addClassDescription(
+      "Computes and reports the critical time step for the explicit solver.");
+  params.addParam<MaterialPropertyName>(
+      "density_name", "rho", "Name of Material Property defining the density of the material.");
+  params.addParam<MaterialPropertyName>(
+      "E_name", "effective_stiffness", "Name of material property defining material stiffness");
+  params.addParam<Real>("factor", 1.0, "Factor to mulitply to the critical time step.");
+  return params;
+}
+
+BetterCriticalTimeStep::BetterCriticalTimeStep(const InputParameters & parameters)
+  : ElementPostprocessor(parameters),
+    _rho_name(getParam<MaterialPropertyName>("density_name")),
+    _material_density(getMaterialPropertyByName<Real>(_rho_name)),
+    _E_name(getParam<MaterialPropertyName>("E_name")),
+    _effective_stiffness(getMaterialPropertyByName<Real>(_E_name)),
+    _factor(getParam<Real>("factor")),
+    _critical_time(std::numeric_limits<Real>::max())
+{
+}
+
+void
+BetterCriticalTimeStep::execute()
+{
+  // Real dens = _material_density[0];
+  _c = std::numeric_limits<Real>::min();
+  for (unsigned qp = 0; qp < _q_point.size(); ++qp)
+  {
+    _c = std::max(_c, _effective_stiffness[qp] / std::sqrt(_material_density[qp]));
+  }
+  // std::cout << _c << std::endl;
+  _critical_time = std::min(_factor * _current_elem->hmin() / _c, _critical_time);
+}
+
+void
+BetterCriticalTimeStep::finalize()
+{
+  gatherMin(_critical_time);
+}
+
+PostprocessorValue
+BetterCriticalTimeStep::getValue()
+{
+  return _critical_time;
+}
+
+void
+BetterCriticalTimeStep::threadJoin(const UserObject & y)
+{
+  const BetterCriticalTimeStep & pps = static_cast<const BetterCriticalTimeStep &>(y);
+  _critical_time = std::min(_critical_time, pps._critical_time);
+}


### PR DESCRIPTION
The current CriticalTimeStep postprocessor in Moose doesn't really play nice with AD, so this allows you to get the material properties from their MaterialPropertyName instead. Also fixes their "flimsy" way of computing the wave speed, and fixes threadJoin akin to LevelSetCFLCondition.