### PR TITLE
Clean up MooseDocs config.yml

### DIFF
--- a/doc/config.yml
+++ b/doc/config.yml
@@ -1,5 +1,5 @@
 Content:
-  - ${RACCOON_DIR}/doc/content
+  - ${ROOT_DIR}/doc/content
   - ${MOOSE_DIR}/framework/doc/content
   - ${MOOSE_DIR}/modules/heat_conduction/doc/content
   - ${MOOSE_DIR}/modules/tensor_mechanics/doc/content
@@ -43,12 +43,7 @@ Extensions:
       \bodyboundary:               "{\\partial\\body}"
       \grad:                       "\\bs{\\nabla}"
   MooseDocs.extensions.appsyntax:
-    executable:                    ${RACCOON_DIR}
-    hide:
-      framework:                   !include ${MOOSE_DIR}/framework/doc/hidden.yml
-      heat_conduction:             !include ${MOOSE_DIR}/modules/heat_conduction/doc/hidden.yml
-      tensor_mechanics:            !include ${MOOSE_DIR}/modules/tensor_mechanics/doc/hidden.yml
-      phase_field:                 !include ${MOOSE_DIR}/modules/phase_field/doc/hidden.yml
+    executable:                    ${ROOT_DIR}
     remove:
       framework:                   !include ${MOOSE_DIR}/framework/doc/remove.yml
   MooseDocs.extensions.common:


### PR DESCRIPTION
The "hide" option was removed a few weeks ago. The ROOT_DIR will allow your moosedocs.py to work without setting RACCOON_DIR.