### PR TITLE
Migrate to travis-ci.com

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "moose"]
 	path = moose
-	url = https://github.com/idaholab/moose.git
-	branch = master
+	url = https://github.com/hugary1995/moose.git
+	branch = custom

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,20 @@
-language:             cpp
+language: cpp
 branches:
   only:
-  - master
+    - master
 jobs:
   include:
-    - name:           "TEST UBUNTU 20.04"
-      os:             linux
-      dist:           focal
+    - name: "TEST UBUNTU 20.04"
+      os: linux
+      dist: focal
       deploy:
-        provider:     pages
-        edge:         true
-        local_dir:    ../gh-pages/
-        cleanup:      false
-        token:        $travis
+        provider: pages
+        edge: true
+        local_dir: ../gh-pages/
+        cleanup: false
+        token: $travis
         on:
-          branch:     master
+          branch: master
       before_install:
         - curl -L -O https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
         - bash Miniconda3-latest-Linux-x86_64.sh -b -p ~/miniconda3
@@ -31,7 +31,7 @@ install:
   - travis_wait 30 conda install moose-libmesh
 script:
   - conda activate moose
-  - make -j 16
+  - make -j 2
   - ./run_tests -j 2
   - mkdir gh-pages
   - cd doc

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,9 @@ branches:
   - master
 jobs:
   include:
-    - name:           "TEST UBUNTU 18.04"
+    - name:           "TEST UBUNTU 20.04"
       os:             linux
-      dist:           bionic
+      dist:           focal
       deploy:
         provider:     pages
         edge:         true
@@ -31,7 +31,7 @@ install:
   - travis_wait 30 conda install moose-libmesh
 script:
   - conda activate moose
-  - make -j 2
+  - make -j 16
   - ./run_tests -j 2
   - mkdir gh-pages
   - cd doc

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-RACCOON [![Build Status](https://travis-ci.org/hugary1995/raccoon.svg?branch=master)](https://travis-ci.org/hugary1995/raccoon) ![merge-chance-badge](https://img.shields.io/endpoint?url=https%3A%2F%2Fmerge-chance.info%2Fbadge%3Frepo%3Dhugary1995/raccoon)
+RACCOON [![Build Status](https://travis-ci.com/hugary1995/raccoon.svg?branch=master)](https://travis-ci.com/hugary1995/raccoon) ![merge-chance-badge](https://img.shields.io/endpoint?url=https%3A%2F%2Fmerge-chance.info%2Fbadge%3Frepo%3Dhugary1995/raccoon)
 =======
 
 RACCOON is built on MOOSE, a massively parallel object-oriented framework for finite element.

--- a/tutorials/soil_desiccation/elasticity.i
+++ b/tutorials/soil_desiccation/elasticity.i
@@ -203,12 +203,12 @@ c = 0.1
 
   automatic_scaling = true
 
-  picard_max_its = 10
-  picard_custom_pp = delta_d
-  disable_picard_residual_norm_check = true
+  fixed_point_max_its = 10
+  custom_pp = delta_d
   custom_abs_tol = 1e-03
   custom_rel_tol = 1e-03
-  accept_on_max_picard_iteration = true
+  disable_fixed_point_residual_norm_check = true
+  accept_on_max_fixed_point_iteration = true
 []
 
 [Outputs]


### PR DESCRIPTION
travis-ci.org is down, so let's migrate to travis-ci.com.
Update build status image and travis recipe.
Update moose.

refs #86 