### PR TITLE
Linear isotropic hardening

### DIFF
--- a/include/materials/hardening_models/LinearIsotropicHardening.h
+++ b/include/materials/hardening_models/LinearIsotropicHardening.h
@@ -1,0 +1,39 @@
+// By: Sina A. V. Based on RACCOON
+
+#pragma once
+
+#include "PlasticHardeningModel.h"
+#include "DerivativeMaterialPropertyNameInterface.h"
+
+class LinearIsotropicHardening : public PlasticHardeningModel,
+                                 public DerivativeMaterialPropertyNameInterface
+{
+public:
+  static InputParameters validParams();
+
+  LinearIsotropicHardening(const InputParameters & parameters);
+
+  virtual ADReal plasticEnergy(const ADReal & ep, const unsigned int derivative = 0) override;
+
+protected:
+  // @{ The plastic energy parameters
+  const ADMaterialProperty<Real> & _sigma_y;
+  const ADMaterialProperty<Real> & _H;
+  // @}
+
+  /// Name of the phase-field variable
+  const VariableName _d_name;
+
+  // @{ Plastic energy density and its derivative w/r/t damage
+  const MaterialPropertyName _psip_name;
+  ADMaterialProperty<Real> & _psip;
+  ADMaterialProperty<Real> & _psip_active;
+  ADMaterialProperty<Real> & _dpsip_dd;
+  // @}
+
+  // @{ The degradation function and its derivative w/r/t damage
+  const MaterialPropertyName _gp_name;
+  const ADMaterialProperty<Real> & _gp;
+  const ADMaterialProperty<Real> & _dgp_dd;
+  // @}
+};

--- a/include/materials/hardening_models/LinearIsotropicHardening.h
+++ b/include/materials/hardening_models/LinearIsotropicHardening.h
@@ -1,4 +1,7 @@
-// By: Sina A. V. Based on RACCOON
+//* This file is part of the RACCOON application
+//* being developed at Dolbow lab at Duke University
+//* http://dolbow.pratt.duke.edu
+//* By: @Sina-av
 
 #pragma once
 

--- a/src/materials/hardening_models/LinearIsotropicHardening.C
+++ b/src/materials/hardening_models/LinearIsotropicHardening.C
@@ -1,4 +1,7 @@
-// By: Sina A. V. Based on RACCOON
+//* This file is part of the RACCOON application
+//* being developed at Dolbow lab at Duke University
+//* http://dolbow.pratt.duke.edu
+//* By: @Sina-av
 
 #include "LinearIsotropicHardening.h"
 
@@ -10,7 +13,8 @@ LinearIsotropicHardening::validParams()
   InputParameters params = PlasticHardeningModel::validParams();
   params.addClassDescription("Plastic hardening following a linear isotropic law.");
 
-  params.addRequiredParam<MaterialPropertyName>("yield_stress", "The initial yield stress $\\sigma_y$");
+  params.addRequiredParam<MaterialPropertyName>("yield_stress",
+                                                "The initial yield stress $\\sigma_y$");
   params.addRequiredParam<MaterialPropertyName>("hardening_modulus", "The hardening modulus $H$");
 
   params.addRequiredCoupledVar("phase_field", "Name of the phase-field (damage) variable");

--- a/src/materials/hardening_models/LinearIsotropicHardening.C
+++ b/src/materials/hardening_models/LinearIsotropicHardening.C
@@ -1,0 +1,66 @@
+// By: Sina A. V. Based on RACCOON
+
+#include "LinearIsotropicHardening.h"
+
+registerMooseObject("raccoonApp", LinearIsotropicHardening);
+
+InputParameters
+LinearIsotropicHardening::validParams()
+{
+  InputParameters params = PlasticHardeningModel::validParams();
+  params.addClassDescription("Plastic hardening following a linear isotropic law.");
+
+  params.addRequiredParam<MaterialPropertyName>("yield_stress", "The initial yield stress $\\sigma_y$");
+  params.addRequiredParam<MaterialPropertyName>("hardening_modulus", "The hardening modulus $H$");
+
+  params.addRequiredCoupledVar("phase_field", "Name of the phase-field (damage) variable");
+  params.addParam<MaterialPropertyName>(
+      "plastic_energy_density",
+      "psip",
+      "Name of the plastic energy density computed by this material model");
+  params.addParam<MaterialPropertyName>("degradation_function", "gp", "The degradation function");
+
+  return params;
+}
+
+LinearIsotropicHardening::LinearIsotropicHardening(const InputParameters & parameters)
+  : PlasticHardeningModel(parameters),
+    DerivativeMaterialPropertyNameInterface(),
+    _sigma_y(getADMaterialProperty<Real>(prependBaseName("yield_stress", true))),
+    _H(getADMaterialProperty<Real>(prependBaseName("hardening_modulus", true))),
+
+    _d_name(getVar("phase_field", 0)->name()),
+
+    // The strain energy density and its derivatives
+    _psip_name(prependBaseName("plastic_energy_density", true)),
+    _psip(declareADProperty<Real>(_psip_name)),
+    _psip_active(declareADProperty<Real>(_psip_name + "_active")),
+    _dpsip_dd(declareADProperty<Real>(derivativePropertyName(_psip_name, {_d_name}))),
+
+    // The degradation function and its derivatives
+    _gp_name(prependBaseName("degradation_function", true)),
+    _gp(getADMaterialProperty<Real>(_gp_name)),
+    _dgp_dd(getADMaterialProperty<Real>(derivativePropertyName(_gp_name, {_d_name})))
+{
+}
+
+ADReal
+LinearIsotropicHardening::plasticEnergy(const ADReal & ep, const unsigned int derivative)
+{
+  if (derivative == 0)
+  {
+    _psip_active[_qp] = _sigma_y[_qp] * ep + _H[_qp] / 2. * ep * ep;
+    _psip[_qp] = _gp[_qp] * _psip_active[_qp];
+    _dpsip_dd[_qp] = _dgp_dd[_qp] * _psip_active[_qp];
+    return _psip[_qp];
+  }
+  // derivative of plastic energy w.r.t equivalent plastic strain ep
+  if (derivative == 1)
+    return _sigma_y[_qp] + _H[_qp] * ep;
+
+  if (derivative == 2)
+    return _H[_qp];
+
+  mooseError(name(), "internal error: unsupported derivative order.");
+  return 0;
+}


### PR DESCRIPTION
Hi!
As the code already has some hardening laws, to be complete and easy to use I added the isotropic hardening law.
Based on works of [Yin et al.](https://www.researchgate.net/publication/341423428_A_ductile_phase-field_model_based_on_degrading_the_fracture_toughness_Theory_and_implementation_at_small_strain) and [Ambati et al.](https://link.springer.com/article/10.1007/s00466-015-1151-4) degradation function is not applied to the yield surface. (But it can be done easily)
Please, let me know if you think this is a good idea, or if it needs work.
Thanks.