### PR TITLE
Added Johnson Cook plasticity model

### DIFF
--- a/src/materials/large_deformation_models/LargeDeformationJ2Plasticity.C
+++ b/src/materials/large_deformation_models/LargeDeformationJ2Plasticity.C
@@ -51,8 +51,17 @@ LargeDeformationJ2Plasticity::updateState(ADRankTwoTensor & stress, ADRankTwoTen
   stress = _elasticity_model->computeCauchyStress(Fe);
   _hardening_model->plasticEnergy(_ep[_qp]);
 
-  // Compute generated heat
-  _heat[_qp] = _hardening_model->plasticDissipation(delta_ep, _ep[_qp], 1) * delta_ep / _dt;
+  // Compute generate heat
+  //  Avoid div/0 issues
+  if (delta_ep > 0 && _ep[_qp] > 0)
+  {
+    _heat[_qp] = _hardening_model->plasticDissipation(delta_ep, _ep[_qp], 1) * delta_ep / _dt;
+  }
+  else
+  {
+    _heat[_qp] = 0;
+  }
+
   _heat[_qp] += _hardening_model->thermalConjugate(_ep[_qp]) * delta_ep / _dt;
 }
 


### PR DESCRIPTION
Added JC plasticity model for use in a variational framework. 
Additionally adds lower bound to return mapping to avoid negative plastic strain values

Issues with documentation. Need to fix variables that need both a super and subscript. 
If someone more knowledgeable in markdown could do that, that would be much appreciated. 

Fixes issue #130 