### PR TITLE
update some function based on upstream/devel

### DIFF
--- a/include/materials/KLRNucleationMicroForce.h
+++ b/include/materials/KLRNucleationMicroForce.h
@@ -65,6 +65,8 @@ protected:
   /// Quantifying how far is the stress state from stress surface
   ADMaterialProperty<Real> & _stress_balance;
 
+  ADMaterialProperty<Real> & _druck_prager_balance;
+
   /// Name of the phase-field variable
   const VariableName _d_name;
   // @{ The degradation function and its derivative w/r/t damage

--- a/include/postprocessors/ExternalWork.h
+++ b/include/postprocessors/ExternalWork.h
@@ -17,7 +17,7 @@ protected:
   virtual void initialize() override;
   virtual void execute() override;
   virtual Real computeQpValue();
-  virtual Real getValue() override;
+  virtual Real getValue() const override;
   virtual void finalize() override;
   virtual void threadJoin(const UserObject & y) override;
 

--- a/include/postprocessors/SolutionChangeNorm.h
+++ b/include/postprocessors/SolutionChangeNorm.h
@@ -13,7 +13,7 @@ public:
 
   SolutionChangeNorm(const InputParameters & parameters);
 
-  virtual Real getValue() override;
+  virtual Real getValue() const override;
 
 protected:
   virtual Real computeQpIntegral() override;

--- a/src/materials/KLBFNucleationMicroForce.C
+++ b/src/materials/KLBFNucleationMicroForce.C
@@ -95,13 +95,13 @@ KLBFNucleationMicroForce::computeQpProperties()
   ADReal gamma_2 = (8 * _mu[_qp] + 24 * K - 27 * _sigma_ts[_qp]) / 144 / _mu[_qp] / K;
   ADReal beta_0 = _delta[_qp] * M;
   ADReal beta_1 = (-gamma_1 * M - gamma_2) * (_sigma_cs[_qp] - _sigma_ts[_qp]) -
-                  gamma_0 * (pow(_sigma_cs[_qp], 3) - pow(_sigma_ts[_qp], 3));
+                  gamma_0 * (std::pow(_sigma_cs[_qp], 3) - std::pow(_sigma_ts[_qp], 3));
   ADReal beta_2 = std::sqrt(3.0) * ((-gamma_1 * M + gamma_2) * (_sigma_cs[_qp] + _sigma_ts[_qp]) +
-                                    gamma_0 * (pow(_sigma_cs[_qp], 3) + pow(_sigma_ts[_qp], 3)));
+                                    gamma_0 * (std::pow(_sigma_cs[_qp], 3) + std::pow(_sigma_ts[_qp], 3)));
   ADReal beta_3 = _L[_qp] * _sigma_ts[_qp] / _mu[_qp] / K / _Gc[_qp];
 
   // Compute the external driving force required to recover the desired strength envelope.
   _ex_driving[_qp] = (beta_2 * std::sqrt(J2) + beta_1 * I1 + beta_0) / (1 + beta_3 * I1 * I1);
 
-  _stress_balance[_qp] = J2 / _mu[_qp] + pow(I1, 2) / 9.0 / K - _ex_driving[_qp] - M;
+  _stress_balance[_qp] = J2 / _mu[_qp] + std::pow(I1, 2) / 9.0 / K - _ex_driving[_qp] - M;
 }

--- a/src/materials/pff_constitutive_functions/CrackGeometricFunction.C
+++ b/src/materials/pff_constitutive_functions/CrackGeometricFunction.C
@@ -15,7 +15,7 @@ CrackGeometricFunction::validParams()
       "function. The initial derivative as well as the normalization constant are automatically "
       "populated given the function definition.");
 
-  params.set<std::string>("f_name") = "alpha";
+  params.set<std::string>("property_name") = "alpha";
   params.addRequiredCoupledVar("phase_field", "The phase-field variable");
 
   params.set<unsigned int>("derivative_order") = 1;

--- a/src/materials/pff_constitutive_functions/DegradationFunctionBase.C
+++ b/src/materials/pff_constitutive_functions/DegradationFunctionBase.C
@@ -9,7 +9,7 @@ DegradationFunctionBase::validParams()
 {
   InputParameters params = CustomParsedFunctionBase::validParams();
 
-  params.set<std::string>("f_name") = "g";
+  params.set<std::string>("property_name") = "g";
   params.addRequiredCoupledVar("phase_field", "The phase-field variable");
 
   params.set<unsigned int>("derivative_order") = 1;

--- a/src/postprocessors/ExternalWork.C
+++ b/src/postprocessors/ExternalWork.C
@@ -60,7 +60,7 @@ ExternalWork::computeQpValue()
 }
 
 Real
-ExternalWork::getValue()
+ExternalWork::getValue() const
 {
   return _sum * _dt + _sum_old;
 }

--- a/src/postprocessors/PhaseFieldJIntegral.C
+++ b/src/postprocessors/PhaseFieldJIntegral.C
@@ -39,7 +39,8 @@ PhaseFieldJIntegral::PhaseFieldJIntegral(const InputParameters & parameters)
 Real
 PhaseFieldJIntegral::computeQpIntegral()
 {
-  RankTwoTensor H((*_grad_disp[0])[_qp], (*_grad_disp[1])[_qp], (*_grad_disp[2])[_qp]);
+  auto H = RankTwoTensor::initializeFromRows(
+      (*_grad_disp[0])[_qp], (*_grad_disp[1])[_qp], (*_grad_disp[2])[_qp]);
   RankTwoTensor I2(RankTwoTensor::initIdentity);
   ADRankTwoTensor Sigma = _psie[_qp] * I2 - H.transpose() * _stress[_qp];
   RealVectorValue n = _normals[_qp];

--- a/src/postprocessors/SolutionChangeNorm.C
+++ b/src/postprocessors/SolutionChangeNorm.C
@@ -26,7 +26,7 @@ SolutionChangeNorm::SolutionChangeNorm(const InputParameters & parameters)
 }
 
 Real
-SolutionChangeNorm::getValue()
+SolutionChangeNorm::getValue() const
 {
   return std::sqrt(ElementIntegralPostprocessor::getValue());
 }


### PR DESCRIPTION
update some object parameter names, function names so that they stop throwing warnings. Changes includes:

The RankTwoTensor initializer in PhaseFieldJIntegral
The "f_name" to "property_name" in CrackGeometricFunction and DegradationFunctionBase

more update based on moose 01a4027:
1. add namespace std to pow function in Nucleation model objects
2. update getValue() function type to const