### PR TITLE
Update for MetaPhysicL 2.0

### DIFF
--- a/src/materials/ArrheniusLaw.C
+++ b/src/materials/ArrheniusLaw.C
@@ -41,6 +41,7 @@ ArrheniusLaw::ArrheniusLaw(const InputParameters & parameters)
 void
 ArrheniusLaw::computeQpProperties()
 {
-  _arrhenius_coef[_qp] = std::exp(-_Q[_qp] / _R / _T[_qp]);
+  using std::exp;
+  _arrhenius_coef[_qp] = exp(-_Q[_qp] / _R / _T[_qp]);
   _darrhenius_coef_dT[_qp] = _arrhenius_coef[_qp] * _Q[_qp] / _R / _T[_qp] / _T[_qp];
 }

--- a/src/materials/hardening_models/ExponentialHardening.C
+++ b/src/materials/hardening_models/ExponentialHardening.C
@@ -55,25 +55,25 @@ ExponentialHardening::ExponentialHardening(const InputParameters & parameters)
 ADReal
 ExponentialHardening::plasticEnergy(const ADReal & ep, const unsigned int derivative)
 {
+  using std::exp;
   if (derivative == 0)
   {
-    _psip_active[_qp] =
-        _sigma_ult[_qp] * ep +
-        _ep0[_qp] * (_sigma_ult[_qp] - _sigma_y[_qp]) * (std::exp(-ep / _ep0[_qp]) - 1) +
-        0.5 * _H[_qp] * ep * ep;
+    using std::exp;
+    _psip_active[_qp] = _sigma_ult[_qp] * ep +
+                        _ep0[_qp] * (_sigma_ult[_qp] - _sigma_y[_qp]) * (exp(-ep / _ep0[_qp]) - 1) +
+                        0.5 * _H[_qp] * ep * ep;
     _psip[_qp] = _gp[_qp] * _psip_active[_qp];
     _dpsip_dd[_qp] = _dgp_dd[_qp] * _psip_active[_qp];
     return _psip[_qp];
   }
 
   if (derivative == 1)
-    return _gp[_qp] *
-           (_sigma_ult[_qp] - (_sigma_ult[_qp] - _sigma_y[_qp]) * std::exp(-ep / _ep0[_qp]) +
-            _H[_qp] * ep);
+    return _gp[_qp] * (_sigma_ult[_qp] - (_sigma_ult[_qp] - _sigma_y[_qp]) * exp(-ep / _ep0[_qp]) +
+                       _H[_qp] * ep);
 
   if (derivative == 2)
     return _gp[_qp] *
-           ((_sigma_ult[_qp] - _sigma_y[_qp]) * std::exp(-ep / _ep0[_qp]) / _ep0[_qp] + _H[_qp]);
+           ((_sigma_ult[_qp] - _sigma_y[_qp]) * exp(-ep / _ep0[_qp]) / _ep0[_qp] + _H[_qp]);
 
   mooseError(name(), "internal error: unsupported derivative order.");
   return 0;

--- a/src/materials/hardening_models/JohnsonCookHardening.C
+++ b/src/materials/hardening_models/JohnsonCookHardening.C
@@ -80,12 +80,13 @@ JohnsonCookHardening::temperatureDependence()
 ADReal
 JohnsonCookHardening::initialGuess(const ADReal & effective_trial_stress)
 {
+  using std::max;
+  using std::pow;
   ADReal trial_over_stress =
       effective_trial_stress / _sigma_0[_qp] / temperatureDependence() - _A[_qp];
   if (trial_over_stress < 0)
     trial_over_stress = 0;
-  return std::max(_ep0 * std::pow(trial_over_stress / _B, 1 / _n),
-                  libMesh::TOLERANCE * libMesh::TOLERANCE);
+  return max(_ep0 * pow(trial_over_stress / _B, 1 / _n), libMesh::TOLERANCE * libMesh::TOLERANCE);
 }
 
 ADReal
@@ -93,8 +94,9 @@ JohnsonCookHardening::plasticEnergy(const ADReal & ep, const unsigned int deriva
 {
   if (derivative == 0)
   {
+    using std::pow;
     _psip_active[_qp] = (1 - _tqf) * _sigma_0[_qp] *
-                        (_A[_qp] * ep + _B * _ep0 * std::pow(ep / _ep0, _n + 1) / (_n + 1)) *
+                        (_A[_qp] * ep + _B * _ep0 * pow(ep / _ep0, _n + 1) / (_n + 1)) *
                         temperatureDependence();
     _psip[_qp] = _gp[_qp] * _psip_active[_qp];
     _dpsip_dd[_qp] = _dgp_dd[_qp] * _psip_active[_qp];
@@ -103,12 +105,14 @@ JohnsonCookHardening::plasticEnergy(const ADReal & ep, const unsigned int deriva
 
   if (derivative == 1)
   {
-    return _gp[_qp] * (1 - _tqf) * _sigma_0[_qp] * (_A[_qp] + _B * std::pow(ep / _ep0, _n)) *
+    using std::pow;
+    return _gp[_qp] * (1 - _tqf) * _sigma_0[_qp] * (_A[_qp] + _B * pow(ep / _ep0, _n)) *
            temperatureDependence();
   }
   if (derivative == 2)
   {
-    return _gp[_qp] * (1 - _tqf) * _sigma_0[_qp] * _B * std::pow(ep / _ep0, _n - 1) * _n / _ep0 *
+    using std::pow;
+    return _gp[_qp] * (1 - _tqf) * _sigma_0[_qp] * _B * pow(ep / _ep0, _n - 1) * _n / _ep0 *
            temperatureDependence();
   }
   mooseError(name(), "internal error: unsupported derivative order.");
@@ -126,27 +130,31 @@ JohnsonCookHardening::plasticDissipation(const ADReal & delta_ep,
 
   if (derivative == 0)
   {
-    result += (_A[_qp] + _B * std::pow(ep / _ep0, _n)) * _tqf * delta_ep;
+    using std::log;
+    using std::pow;
+    result += (_A[_qp] + _B * pow(ep / _ep0, _n)) * _tqf * delta_ep;
     if (_t_step > 0 && delta_ep > libMesh::TOLERANCE * libMesh::TOLERANCE)
-      result += (_A[_qp] + _B * std::pow(ep / _ep0, _n)) *
-                (_C * std::log(delta_ep / _dt / _epdot0) - _C) * delta_ep;
+      result += (_A[_qp] + _B * pow(ep / _ep0, _n)) * (_C * log(delta_ep / _dt / _epdot0) - _C) *
+                delta_ep;
   }
 
   if (derivative == 1)
   {
-    result += (_A[_qp] + _B * std::pow(ep / _ep0, _n)) * _tqf;
+    using std::log;
+    using std::pow;
+    result += (_A[_qp] + _B * pow(ep / _ep0, _n)) * _tqf;
     if (_t_step > 0 && delta_ep > libMesh::TOLERANCE * libMesh::TOLERANCE)
-      result +=
-          (_A[_qp] + _B * std::pow(ep / _ep0, _n)) * (_C * std::log(delta_ep / _dt / _epdot0));
+      result += (_A[_qp] + _B * pow(ep / _ep0, _n)) * (_C * log(delta_ep / _dt / _epdot0));
   }
 
   if (derivative == 2)
   {
-    result += _B * std::pow(ep / _ep0, _n - 1) * _n / _ep0 * _tqf;
+    using std::log;
+    using std::pow;
+    result += _B * pow(ep / _ep0, _n - 1) * _n / _ep0 * _tqf;
     if (_t_step > 0 && delta_ep > libMesh::TOLERANCE * libMesh::TOLERANCE)
-      result +=
-          (_A[_qp] + _B * std::pow(ep / _ep0, _n)) * _C / delta_ep +
-          _B * std::pow(ep / _ep0, _n - 1) * _n / _ep0 * _C * std::log(delta_ep / _dt / _epdot0);
+      result += (_A[_qp] + _B * pow(ep / _ep0, _n)) * _C / delta_ep +
+                _B * pow(ep / _ep0, _n - 1) * _n / _ep0 * _C * log(delta_ep / _dt / _epdot0);
   }
 
   return _gp[_qp] * result * _sigma_0[_qp] * temperatureDependence();
@@ -157,8 +165,8 @@ JohnsonCookHardening::plasticDissipation(const ADReal & delta_ep,
 ADReal // Thermal conjugate term
 JohnsonCookHardening::thermalConjugate(const ADReal & ep)
 {
+  using std::pow;
 
-  return _gp[_qp] * _T[_qp] * (1 - _tqf) * _sigma_0[_qp] *
-         (_A[_qp] + _B * std::pow(ep / _ep0, _n)) *
-         (_m * (std::pow((_T0 - _T[_qp]) / (_T0 - _Tm), _m))) / (_T0 - _T[_qp]);
+  return _gp[_qp] * _T[_qp] * (1 - _tqf) * _sigma_0[_qp] * (_A[_qp] + _B * pow(ep / _ep0, _n)) *
+         (_m * (pow((_T0 - _T[_qp]) / (_T0 - _Tm), _m))) / (_T0 - _T[_qp]);
 }

--- a/src/materials/hardening_models/PowerLawHardening.C
+++ b/src/materials/hardening_models/PowerLawHardening.C
@@ -53,20 +53,22 @@ PowerLawHardening::PowerLawHardening(const InputParameters & parameters)
 ADReal
 PowerLawHardening::plasticEnergy(const ADReal & ep, const unsigned int derivative)
 {
+  using std::pow;
   if (derivative == 0)
   {
+    using std::pow;
     _psip_active[_qp] = _n[_qp] * _sigma_y[_qp] * _ep0[_qp] / (_n[_qp] + 1) *
-                        (std::pow(1 + ep / _ep0[_qp], 1 / _n[_qp] + 1) - 1);
+                        (pow(1 + ep / _ep0[_qp], 1 / _n[_qp] + 1) - 1);
     _psip[_qp] = _gp[_qp] * _psip_active[_qp];
     _dpsip_dd[_qp] = _dgp_dd[_qp] * _psip_active[_qp];
     return _psip[_qp];
   }
 
   if (derivative == 1)
-    return _gp[_qp] * _sigma_y[_qp] * std::pow(1 + ep / _ep0[_qp], 1 / _n[_qp]);
+    return _gp[_qp] * _sigma_y[_qp] * pow(1 + ep / _ep0[_qp], 1 / _n[_qp]);
 
   if (derivative == 2)
-    return _gp[_qp] * _sigma_y[_qp] * std::pow(1 + ep / _ep0[_qp], 1 / _n[_qp] - 1) / _n[_qp] /
+    return _gp[_qp] * _sigma_y[_qp] * pow(1 + ep / _ep0[_qp], 1 / _n[_qp] - 1) / _n[_qp] /
            _ep0[_qp];
 
   mooseError(name(), "internal error: unsupported derivative order.");

--- a/src/materials/large_deformation_models/CNHIsotropicElasticity.C
+++ b/src/materials/large_deformation_models/CNHIsotropicElasticity.C
@@ -71,6 +71,7 @@ ADRankTwoTensor
 CNHIsotropicElasticity::computeMandelStressNoDecomposition(const ADRankTwoTensor & Fe,
                                                            const bool plasticity_update)
 {
+  using std::sqrt;
   // We use the left Cauchy-Green strain
   ADRankTwoTensor strain;
   if (plasticity_update)
@@ -81,7 +82,7 @@ CNHIsotropicElasticity::computeMandelStressNoDecomposition(const ADRankTwoTensor
   else
     strain = Fe * Fe.transpose();
 
-  ADReal J = std::sqrt(strain.det());
+  ADReal J = sqrt(strain.det());
 
   const ADRankTwoTensor I2(ADRankTwoTensor::initIdentity);
   // Here, we keep the volumetric part no matter what. But ideally, in the case of J2 plasticity,
@@ -93,8 +94,10 @@ CNHIsotropicElasticity::computeMandelStressNoDecomposition(const ADRankTwoTensor
   // compute the strain energy density
   if (!plasticity_update)
   {
-    ADRankTwoTensor strain_bar = std::pow(J, -2. / 3.) * strain;
-    ADReal U = 0.5 * _K[_qp] * (0.5 * (J * J - 1) - std::log(J));
+    using std::log;
+    using std::pow;
+    ADRankTwoTensor strain_bar = pow(J, -2. / 3.) * strain;
+    ADReal U = 0.5 * _K[_qp] * (0.5 * (J * J - 1) - log(J));
     ADReal W = 0.5 * _G[_qp] * (strain_bar.trace() - 3.0);
     _psie_active[_qp] = U + W;
     _psie[_qp] = _g[_qp] * _psie_active[_qp];
@@ -108,6 +111,7 @@ ADRankTwoTensor
 CNHIsotropicElasticity::computeMandelStressVolDevDecomposition(const ADRankTwoTensor & Fe,
                                                                const bool plasticity_update)
 {
+  using std::sqrt;
   // We use the left Cauchy-Green strain
   ADRankTwoTensor strain;
   if (plasticity_update)
@@ -118,7 +122,7 @@ CNHIsotropicElasticity::computeMandelStressVolDevDecomposition(const ADRankTwoTe
   else
     strain = Fe * Fe.transpose();
 
-  ADReal J = std::sqrt(strain.det());
+  ADReal J = sqrt(strain.det());
 
   const ADRankTwoTensor I2(ADRankTwoTensor::initIdentity);
   // Here, we keep the volumetric part no matter what. But ideally, in the case of J2 plasticity,
@@ -132,8 +136,10 @@ CNHIsotropicElasticity::computeMandelStressVolDevDecomposition(const ADRankTwoTe
   // compute the strain energy density
   if (!plasticity_update)
   {
-    ADRankTwoTensor strain_bar = std::pow(J, -2. / 3.) * strain;
-    ADReal U = 0.5 * _K[_qp] * (0.5 * (J * J - 1) - std::log(J));
+    using std::log;
+    using std::pow;
+    ADRankTwoTensor strain_bar = pow(J, -2. / 3.) * strain;
+    ADReal U = 0.5 * _K[_qp] * (0.5 * (J * J - 1) - log(J));
     ADReal W = 0.5 * _G[_qp] * (strain_bar.trace() - 3.0);
     _psie_active[_qp] = J > 1 ? U + W : W;
     _psie[_qp] = _g[_qp] * _psie_active[_qp];

--- a/src/materials/large_deformation_models/ComputeDeformationGradient.C
+++ b/src/materials/large_deformation_models/ComputeDeformationGradient.C
@@ -123,8 +123,9 @@ ComputeDeformationGradient::computeProperties()
 
   for (_qp = 0; _qp < _qrule->n_points(); ++_qp)
   {
+    using std::cbrt;
     if (_volumetric_locking_correction)
-      _F[_qp] *= std::cbrt(ave_F_det / _F[_qp].det());
+      _F[_qp] *= cbrt(ave_F_det / _F[_qp].det());
 
     // Remove the eigen deformation gradient
     ADRankTwoTensor Fg(ADRankTwoTensor::initIdentity);

--- a/src/materials/large_deformation_models/LargeDeformationJ2Plasticity.C
+++ b/src/materials/large_deformation_models/LargeDeformationJ2Plasticity.C
@@ -25,6 +25,7 @@ LargeDeformationJ2Plasticity::LargeDeformationJ2Plasticity(const InputParameters
 void
 LargeDeformationJ2Plasticity::updateState(ADRankTwoTensor & stress, ADRankTwoTensor & Fe)
 {
+  using std::sqrt;
   // First assume no plastic increment
   ADReal delta_ep = 0;
   Fe = Fe * _Fp_old[_qp].inverse();
@@ -36,7 +37,7 @@ LargeDeformationJ2Plasticity::updateState(ADRankTwoTensor & stress, ADRankTwoTen
   ADReal stress_dev_norm = stress_dev.doubleContraction(stress_dev);
   if (MooseUtils::absoluteFuzzyEqual(stress_dev_norm, 0))
     stress_dev_norm.value() = libMesh::TOLERANCE * libMesh::TOLERANCE;
-  stress_dev_norm = std::sqrt(1.5 * stress_dev_norm);
+  stress_dev_norm = sqrt(1.5 * stress_dev_norm);
   _Np[_qp] = 1.5 * stress_dev / stress_dev_norm;
   // Return mapping
   ADReal phi = computeResidual(stress_dev_norm, delta_ep);

--- a/src/materials/large_deformation_models/LargeDeformationJ2PowerLawCreep.C
+++ b/src/materials/large_deformation_models/LargeDeformationJ2PowerLawCreep.C
@@ -32,6 +32,7 @@ ADReal
 LargeDeformationJ2PowerLawCreep::computeResidual(const ADReal & effective_trial_stress,
                                                  const ADReal & delta_ep)
 {
+  using std::pow;
   const ADReal stress_delta =
       effective_trial_stress -
       _elasticity_model->computeMandelStress(delta_ep * _Np[_qp], /*plasticity_update = */ true)
@@ -39,7 +40,7 @@ LargeDeformationJ2PowerLawCreep::computeResidual(const ADReal & effective_trial_
   const ADReal yield_stress =
       _hardening_model->plasticEnergy(_ep_old[_qp] + delta_ep, 1) +
       _hardening_model->plasticDissipation(delta_ep, _ep_old[_qp] + delta_ep, 1);
-  const ADReal creep_rate = _coefficient * std::pow(stress_delta / yield_stress, _exponent);
+  const ADReal creep_rate = _coefficient * pow(stress_delta / yield_stress, _exponent);
   return creep_rate * _dt - delta_ep;
 }
 
@@ -47,6 +48,7 @@ ADReal
 LargeDeformationJ2PowerLawCreep::computeDerivative(const ADReal & effective_trial_stress,
                                                    const ADReal & delta_ep)
 {
+  using std::pow;
   const ADReal stress_delta =
       effective_trial_stress -
       _elasticity_model->computeMandelStress(delta_ep * _Np[_qp], /*plasticity_update = */ true)
@@ -61,7 +63,7 @@ LargeDeformationJ2PowerLawCreep::computeDerivative(const ADReal & effective_tria
       _hardening_model->plasticEnergy(_ep_old[_qp] + delta_ep, 2) +
       _hardening_model->plasticDissipation(delta_ep, _ep_old[_qp] + delta_ep, 2);
   const ADReal dcreep_rate =
-      _coefficient * _exponent * std::pow(stress_delta / yield_stress, _exponent - 1);
+      _coefficient * _exponent * pow(stress_delta / yield_stress, _exponent - 1);
   return dcreep_rate *
              (dstress_delta_ddelta_ep * yield_stress - stress_delta * dyield_stress_ddelta_ep) /
              yield_stress / yield_stress * _dt -

--- a/src/materials/nucleation_models/KLBFNucleationMicroForce.C
+++ b/src/materials/nucleation_models/KLBFNucleationMicroForce.C
@@ -36,6 +36,8 @@ KLBFNucleationMicroForce::KLBFNucleationMicroForce(const InputParameters & param
 void
 KLBFNucleationMicroForce::computeQpProperties()
 {
+  using std::pow;
+  using std::sqrt;
   // The bulk modulus
   ADReal K = _lambda[_qp] + 2 * _mu[_qp] / 3;
 
@@ -62,14 +64,13 @@ KLBFNucleationMicroForce::computeQpProperties()
   ADReal gamma_2 = (8 * _mu[_qp] + 24 * K - 27 * _sigma_ts[_qp]) / 144 / _mu[_qp] / K;
   ADReal beta_0 = _delta[_qp] * M;
   ADReal beta_1 = (-gamma_1 * M - gamma_2) * (_sigma_cs[_qp] - _sigma_ts[_qp]) -
-                  gamma_0 * (std::pow(_sigma_cs[_qp], 3) - std::pow(_sigma_ts[_qp], 3));
-  ADReal beta_2 =
-      std::sqrt(3.0) * ((-gamma_1 * M + gamma_2) * (_sigma_cs[_qp] + _sigma_ts[_qp]) +
-                        gamma_0 * (std::pow(_sigma_cs[_qp], 3) + std::pow(_sigma_ts[_qp], 3)));
+                  gamma_0 * (pow(_sigma_cs[_qp], 3) - pow(_sigma_ts[_qp], 3));
+  ADReal beta_2 = sqrt(3.0) * ((-gamma_1 * M + gamma_2) * (_sigma_cs[_qp] + _sigma_ts[_qp]) +
+                               gamma_0 * (pow(_sigma_cs[_qp], 3) + pow(_sigma_ts[_qp], 3)));
   ADReal beta_3 = _L[_qp] * _sigma_ts[_qp] / _mu[_qp] / K / _Gc[_qp];
 
   // Compute the external driving force required to recover the desired strength envelope.
-  _ex_driving[_qp] = (beta_2 * std::sqrt(J2) + beta_1 * I1 + beta_0) / (1 + beta_3 * I1 * I1);
+  _ex_driving[_qp] = (beta_2 * sqrt(J2) + beta_1 * I1 + beta_0) / (1 + beta_3 * I1 * I1);
 
-  _stress_balance[_qp] = J2 / _mu[_qp] + std::pow(I1, 2) / 9.0 / K - _ex_driving[_qp] - M;
+  _stress_balance[_qp] = J2 / _mu[_qp] + pow(I1, 2) / 9.0 / K - _ex_driving[_qp] - M;
 }

--- a/src/materials/nucleation_models/KLRNucleationMicroForce.C
+++ b/src/materials/nucleation_models/KLRNucleationMicroForce.C
@@ -38,6 +38,8 @@ KLRNucleationMicroForce::KLRNucleationMicroForce(const InputParameters & paramet
 void
 KLRNucleationMicroForce::computeQpProperties()
 {
+  using std::pow;
+  using std::sqrt;
   // The bulk modulus
   ADReal K = _lambda[_qp] + 2 * _mu[_qp] / 3;
 
@@ -66,19 +68,19 @@ KLRNucleationMicroForce::computeQpProperties()
   ADReal gamma_1 = (1.0 + _delta[_qp]) / (2.0 * _sigma_ts[_qp] * _sigma_cs[_qp]);
   ADReal beta_0 = _delta[_qp] * M;
   ADReal beta_1 = -gamma_1 * M * (_sigma_cs[_qp] - _sigma_ts[_qp]) + gamma_0;
-  ADReal beta_2 = std::sqrt(3.0) * (-gamma_1 * M * (_sigma_cs[_qp] + _sigma_ts[_qp]) + gamma_0);
+  ADReal beta_2 = sqrt(3.0) * (-gamma_1 * M * (_sigma_cs[_qp] + _sigma_ts[_qp]) + gamma_0);
   ADReal beta_3 = _L[_qp] * _sigma_ts[_qp] / _mu[_qp] / K / _Gc[_qp];
 
   // Compute the external driving force required to recover the desired strength envelope.
   _ex_driving[_qp] =
-      (beta_2 * std::sqrt(J2) + beta_1 * I1 + beta_0) +
-      (1.0 - std::sqrt(I1 * I1) / I1) / std::pow(_g[_qp], 1.5) *
+      (beta_2 * sqrt(J2) + beta_1 * I1 + beta_0) +
+      (1.0 - sqrt(I1 * I1) / I1) / pow(_g[_qp], 1.5) *
           (J2 / 2.0 / _mu[_qp] + I1 * I1 / 6.0 / (3.0 * _lambda[_qp] + 2.0 * _mu[_qp]));
 
-  _stress_balance[_qp] = J2 / _mu[_qp] + std::pow(I1, 2) / 9.0 / K - _ex_driving[_qp] - M;
+  _stress_balance[_qp] = J2 / _mu[_qp] + pow(I1, 2) / 9.0 / K - _ex_driving[_qp] - M;
 
   _druck_prager_balance[_qp] =
-      std::sqrt(J2) +
-      (_sigma_cs[_qp] - _sigma_ts[_qp]) / std::sqrt(3.0) / (_sigma_cs[_qp] + _sigma_ts[_qp]) * I1 -
-      2.0 * _sigma_ts[_qp] * _sigma_cs[_qp] / std::sqrt(3.0) / (_sigma_cs[_qp] + _sigma_ts[_qp]);
+      sqrt(J2) +
+      (_sigma_cs[_qp] - _sigma_ts[_qp]) / sqrt(3.0) / (_sigma_cs[_qp] + _sigma_ts[_qp]) * I1 -
+      2.0 * _sigma_ts[_qp] * _sigma_cs[_qp] / sqrt(3.0) / (_sigma_cs[_qp] + _sigma_ts[_qp]);
 }

--- a/src/materials/small_deformation_models/SmallDeformationJ2Plasticity.C
+++ b/src/materials/small_deformation_models/SmallDeformationJ2Plasticity.C
@@ -24,6 +24,7 @@ void
 SmallDeformationJ2Plasticity::updateState(ADRankTwoTensor & stress,
                                           ADRankTwoTensor & elastic_strain)
 {
+  using std::sqrt;
   // First assume no plastic increment
   ADReal delta_ep = 0;
   elastic_strain -= _plastic_strain_old[_qp];
@@ -35,7 +36,7 @@ SmallDeformationJ2Plasticity::updateState(ADRankTwoTensor & stress,
   ADReal stress_dev_norm = stress_dev.doubleContraction(stress_dev);
   if (MooseUtils::absoluteFuzzyEqual(stress_dev_norm, 0))
     stress_dev_norm.value() = libMesh::TOLERANCE * libMesh::TOLERANCE;
-  stress_dev_norm = std::sqrt(1.5 * stress_dev_norm);
+  stress_dev_norm = sqrt(1.5 * stress_dev_norm);
   _Np[_qp] = 1.5 * stress_dev / stress_dev_norm;
 
   // Return mapping

--- a/src/utils/RaccoonUtils.C
+++ b/src/utils/RaccoonUtils.C
@@ -13,9 +13,10 @@ namespace RaccoonUtils
 ADReal
 Macaulay(const ADReal x, const bool deriv)
 {
+  using std::abs;
   if (deriv)
     return x > 0 ? 1 : 0;
-  return 0.5 * (x + std::abs(x));
+  return 0.5 * (x + abs(x));
 }
 
 std::vector<ADReal>
@@ -42,11 +43,12 @@ spectralDecomposition(const ADRankTwoTensor & r2t)
 ADRankTwoTensor
 log(const ADRankTwoTensor & r2t)
 {
+  using std::log;
   std::vector<ADReal> d;
   ADRankTwoTensor V, D;
   r2t.symmetricEigenvaluesEigenvectors(d, V);
   for (auto & di : d)
-    di = std::log(di);
+    di = log(di);
   D.fillFromInputVector(d);
   return V * D * V.transpose();
 }
@@ -54,11 +56,12 @@ log(const ADRankTwoTensor & r2t)
 ADRankTwoTensor
 exp(const ADRankTwoTensor & r2t)
 {
+  using std::exp;
   std::vector<ADReal> d;
   ADRankTwoTensor V, D;
   r2t.symmetricEigenvaluesEigenvectors(d, V);
   for (auto & di : d)
-    di = std::exp(di);
+    di = exp(di);
   D.fillFromInputVector(d);
   return V * D * V.transpose();
 }


### PR DESCRIPTION
Refs incoming MetaPhysicL 2.0 changes in
[idaholab/moose#31906](https://github.com/idaholab/moose/pull/31906). MetaPhysicL used to put its overloads in the std namespace which is not standard compliant. However, this is fixed in MetaPhysicL 2.0. This patch will allow both backward and forward compatibility with MetaPhysicL 1 and 2 respectively